### PR TITLE
Re-generate API token on re-provisioning [EN-1039]

### DIFF
--- a/models/app.go
+++ b/models/app.go
@@ -16,7 +16,7 @@ type App struct {
 	AppSlug           string         `json:"app_slug"`
 	Plan              string         `json:"plan"`
 	BitriseAPIToken   string         `json:"-"`
-	APIToken          string         `json:"-"`
+	APIToken          string         `db:"api_token" json:"-"`
 	EncryptedSecret   []byte         `json:"-"`
 	EncryptedSecretIV []byte         `json:"-"`
 	HeaderColor1      string         `db:"header_color_1" gorm:"column:header_color_1" json:"header_color_1"`

--- a/services/app_service_for_test.go
+++ b/services/app_service_for_test.go
@@ -5,7 +5,7 @@ import "github.com/bitrise-io/addons-ship-backend/models"
 type testAppService struct {
 	createFn func(*models.App) (*models.App, error)
 	findFn   func(*models.App) (*models.App, error)
-	updateFn func(*models.App) ([]error, error)
+	updateFn func(*models.App, []string) ([]error, error)
 	deleteFn func(*models.App) error
 }
 
@@ -25,7 +25,7 @@ func (a *testAppService) Find(app *models.App) (*models.App, error) {
 
 func (a *testAppService) Update(app *models.App, whitelist []string) (validationErrors []error, dbErr error) {
 	if a.updateFn != nil {
-		return a.updateFn(app)
+		return a.updateFn(app, whitelist)
 	}
 	panic("You have to override Update function in tests")
 }

--- a/services/provision_test.go
+++ b/services/provision_test.go
@@ -28,34 +28,24 @@ func Test_ProvisionHandler(t *testing.T) {
 		requestBody: `{}`,
 	})
 
-	t.Run("ok", func(t *testing.T) {
-		performControllerTest(t, httpMethod, url, handler, ControllerTestCase{
-			env: &env.AppEnv{
-				AppService: &testAppService{
-					findFn: func(app *models.App) (*models.App, error) {
-						return app, nil
-					},
-				},
-				BitriseAPI: &testBitriseAPI{},
-			},
-			requestBody:        `{}`,
-			expectedStatusCode: http.StatusOK,
-			expectedResponse: services.ProvisionPostResponse{
-				Envs: []services.Env{
-					services.Env{Key: "ADDON_SHIP_API_URL"},
-					services.Env{Key: "ADDON_SHIP_API_TOKEN"},
-				},
-			},
-		})
-	})
-
 	t.Run("ok when app exists", func(t *testing.T) {
 		performControllerTest(t, httpMethod, url, handler, ControllerTestCase{
 			env: &env.AppEnv{
+				AddonHostURL: "http://ship.addon.url",
 				AppService: &testAppService{
 					findFn: func(app *models.App) (*models.App, error) {
 						require.Equal(t, "test-app-slug", app.AppSlug)
+						app.APIToken = "existing-token"
 						return app, nil
+					},
+					updateFn: func(app *models.App, whitelist []string) ([]error, error) {
+						require.Equal(t, []string{"APIToken"}, whitelist)
+						require.NotEmpty(t, app.APIToken)
+						require.NotEqual(t, app.APIToken, "existing-token")
+
+						// overwrite random token so we can make response expectations
+						app.APIToken = "new-random-token"
+						return nil, nil
 					},
 				},
 				BitriseAPI: &testBitriseAPI{},
@@ -64,8 +54,8 @@ func Test_ProvisionHandler(t *testing.T) {
 			expectedStatusCode: http.StatusOK,
 			expectedResponse: services.ProvisionPostResponse{
 				Envs: []services.Env{
-					services.Env{Key: "ADDON_SHIP_API_URL"},
-					services.Env{Key: "ADDON_SHIP_API_TOKEN"},
+					{Key: "ADDON_SHIP_API_URL", Value: "http://ship.addon.url"},
+					{Key: "ADDON_SHIP_API_TOKEN", Value: "new-random-token"},
 				},
 			},
 		})
@@ -113,8 +103,8 @@ func Test_ProvisionHandler(t *testing.T) {
 			expectedStatusCode: http.StatusOK,
 			expectedResponse: services.ProvisionPostResponse{
 				Envs: []services.Env{
-					services.Env{Key: "ADDON_SHIP_API_URL", Value: "http://ship.addon.url"},
-					services.Env{Key: "ADDON_SHIP_API_TOKEN", Value: "test-api-token"},
+					{Key: "ADDON_SHIP_API_URL", Value: "http://ship.addon.url"},
+					{Key: "ADDON_SHIP_API_TOKEN", Value: "test-api-token"},
 				},
 			},
 		})

--- a/services/provision_test.go
+++ b/services/provision_test.go
@@ -128,7 +128,7 @@ func Test_ProvisionHandler(t *testing.T) {
 		})
 	})
 
-	t.Run("when database error happest at find", func(t *testing.T) {
+	t.Run("when database error happens at find", func(t *testing.T) {
 		performControllerTest(t, httpMethod, url, handler, ControllerTestCase{
 			env: &env.AppEnv{
 				AppService: &testAppService{


### PR DESCRIPTION
In order to seamlessly rotate API tokens generated by add-ons
and stored in Website, we need to support re-provisioning
of already existing apps - we need to regenerate
and send a new token in this case.

Manually tested in development environment:
- app provisioning (with authorization switched off and Website API calls disabled): returned with api token and persisted in DB
- same app provisioned again: returned with new api token and persisted it in DB, other data hasn't changed